### PR TITLE
Modulepath

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,3 +9,4 @@ project_page 'https://github.com/nesi/puppet-puppet'
 
 ## Add dependencies, if any:
 # dependency 'username/name', '>= 1.2.0'
+dependency 'puppetlabs/stdlib', '>= 4.1.0'

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -45,7 +45,12 @@ class puppet::conf (
     }
   } else {
     if $module_path {
-      $module_path_change = "set main/modulepath ${module_path}"
+      if is_array($module_path) {
+        $modulepath_list = join($module_path,':')
+      } else {
+        $modulepath_list = $module_path
+      }
+      $module_path_change = "set main/modulepath ${modulepath_list}"
     } else {
       if $puppet::environments {
         $module_path_change = "set main/modulepath \$confdir/environments/${::environment}/modules:\$confdir/modules"

--- a/spec/classes/conf_spec.rb
+++ b/spec/classes/conf_spec.rb
@@ -231,6 +231,18 @@ describe 'puppet::conf', :type => :class do
           it { should execute.idempotently }
         end
       end
+      describe 'with a list of module paths' do
+        let :params do
+            { :module_path => ['/this/path','/that/path','/some/other/path'] }
+        end
+        describe_augeas 'puppet_main_conf', :lens => 'Puppet', :target => 'etc/puppet/puppet.conf', :fixtures => 'etc/puppet/debian.puppet.conf' do
+          it { should execute.with_change}
+          it 'modulepath should be /this/path:/that/path:/some/other/path' do
+            aug_get('main/modulepath').should == '/this/path:/that/path:/some/other/path'
+          end
+          it { should execute.idempotently }
+        end
+      end
     end
   end
 
@@ -290,6 +302,58 @@ describe 'puppet::conf', :type => :class do
           end
           it 'modulepath should be set' do
             aug_get('main/modulepath').should == '$basemodulepath'
+          end
+          it { should execute.idempotently }
+        end
+      end
+      describe 'when given a module path' do
+        let :params do
+            { :module_path => '/some/other/path' }
+        end
+        describe_augeas 'puppet_main_conf', :lens => 'Puppet', :target => 'etc/puppet/puppet.conf', :fixtures => 'etc/puppet/debian.puppet.conf' do
+          it { should execute.with_change}
+          it 'modulepath should be /some/other/path:$basemodulepath' do
+            aug_get('main/modulepath').should == '/some/other/path:$basemodulepath'
+          end
+          it { should execute.idempotently }
+        end
+      end
+      describe 'with a list of module paths' do
+        let :params do
+            { :module_path => ['/this/path','/that/path','/some/other/path'] }
+        end
+        describe_augeas 'puppet_main_conf', :lens => 'Puppet', :target => 'etc/puppet/puppet.conf', :fixtures => 'etc/puppet/debian.puppet.conf' do
+          it { should execute.with_change}
+          it 'modulepath should be /this/path:/that/path:/some/other/path:$basemodulepath' do
+            aug_get('main/modulepath').should == '/this/path:/that/path:/some/other/path:$basemodulepath'
+          end
+          it { should execute.idempotently }
+        end
+      end
+      describe 'when given a module path and disable appending $basemodulepath' do
+        let :params do {
+            :module_path            => '/some/other/path',
+            :append_basemodulepath  => false
+          }
+        end
+        describe_augeas 'puppet_main_conf', :lens => 'Puppet', :target => 'etc/puppet/puppet.conf', :fixtures => 'etc/puppet/debian.puppet.conf' do
+          it { should execute.with_change}
+          it 'modulepath should be /some/other/path' do
+            aug_get('main/modulepath').should == '/some/other/path'
+          end
+          it { should execute.idempotently }
+        end
+      end
+      describe 'with a list of module paths and disable appending $basemodulepath' do
+        let :params do {
+            :module_path            => ['/this/path','/that/path','/some/other/path'],
+            :append_basemodulepath  => false
+          }
+        end
+        describe_augeas 'puppet_main_conf', :lens => 'Puppet', :target => 'etc/puppet/puppet.conf', :fixtures => 'etc/puppet/debian.puppet.conf' do
+          it { should execute.with_change}
+          it 'modulepath should be /this/path:/that/path:/some/other/path' do
+            aug_get('main/modulepath').should == '/this/path:/that/path:/some/other/path'
           end
           it { should execute.idempotently }
         end


### PR DESCRIPTION
Changes to the `modulepath` parameter for `puppet::conf` to:
- handle lists of paths
- handle the new `$basemodulepath` variable introduced in Puppet 3.5.0
