### PR TITLE
move agent config out of if statement to allow puppet runs with cron

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -179,12 +179,12 @@ class puppet (
     order   => '00',
   }
 
+  concat::fragment{'puppet_conf_agent':
+    target  => 'puppet_conf',
+    content => template('puppet/puppet.conf.agent.erb'),
+    order   => '20',
+  }
   if $agent == 'running' {
-    concat::fragment{'puppet_conf_agent':
-      target  => 'puppet_conf',
-      content => template('puppet/puppet.conf.agent.erb'),
-      order   => '20',
-    }
     $puppet_default_status = 'yes'
   } else {
     $puppet_default_status = 'no'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -71,7 +71,7 @@ describe 'puppet', :type => :class do
         'target'  => 'puppet_conf',
         'order'   => '00'
       )}
-      it { should_not contain_concat__fragment('puppet_conf_agent')}
+      it { should contain_concat__fragment('puppet_conf_agent')}
       it { should contain_service('puppet_agent').with(
         'ensure'      => 'stopped',
         'name'        => 'puppet',
@@ -114,7 +114,7 @@ describe 'puppet', :type => :class do
       it { should contain_concat__fragment('puppet_conf_base').without_content(
         %r{^  # Setting templatedir is depreciated since version 3.6.0$\s*^templatedir   = }
       )}
-      it { should_not contain_concat__fragment('puppet_conf_agent') }
+      it { should contain_concat__fragment('puppet_conf_agent') }
     end
     describe 'with ensure => absent' do
       let :params do


### PR DESCRIPTION
The agent config should be done anyway, because if someone runs the puppet agent with cron he would have to set $agent to running to get the agent config in puppet.conf.