### PR TITLE
add ability to manage hiera.yaml after deployment. closes #19

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -67,6 +67,7 @@ The hiera class currently makes the minimum changes required to suppress warning
 ### Parameters
 
 * **ensure**: Sets the ensure state of the heira package and configuration. The default is to match the same state as given the `puppet` class.
+* **hiera_config_manage**: true or false. Default: false. If set to false, the hiera.yaml file will just be placed there once. Setting it to true also updates the config when changed in Puppet.
 * **hiera_config_file**: Sets the path to the file to the hiera configuration in `puppet.conf`. The default is `/etc/puppet/hiera.yaml`.
 * **hiera_datadir**: Sets the path to the directory that holds the Hiera data store. The default is `/etc/puppet/hiradata`.
 * **hiera_config_source**: If this is set, the string given will be used as a puppet file source for the yaml configuration. The default is `undef` which will use the minimal bootstrap template.

--- a/manifests/hiera.pp
+++ b/manifests/hiera.pp
@@ -5,6 +5,7 @@ class puppet::hiera(
   $ensure               = 'installed',
   $hiera_conf_path      = $::puppet::hiera_conf_path,
   $hiera_data_dir       = $::puppet::hiera_data_dir,
+  $hiera_config_manage  = false,
   $hiera_config_source  = undef,
   $hiera_config_content = undef,
   $hiera_backend        = 'yaml',
@@ -53,7 +54,7 @@ class puppet::hiera(
       source  => $hiera_config_source,
       owner   => $user,
       group   => $group,
-      replace => false,
+      replace => $hiera_config_manage,
       require => Package['hiera'],
     }
   } else {
@@ -68,7 +69,7 @@ class puppet::hiera(
       content => $real_config_content,
       owner   => $user,
       group   => $group,
-      replace => false,
+      replace => $hiera_config_manage,
       require => Package['hiera'],
     }
   }


### PR DESCRIPTION
Setting the paramater `hiera_config_manage` to true updates the
hiera.yaml configuration file when its content changes. The only
missing piece: Puppetmaster (Apache) needs a reload to pick up
the new configuration which is not handled by this class.
Leaving the parameter in its default value `false` does not touch
the file once deployed.