### PR TITLE
Support puppet4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,8 +40,7 @@ class puppet::params{
       # Do nothing
     }
     default:{
-      #fail("The NeSI Puppet Puppet module does not support ${::osfamily} family of operating systems")
-      notify{"What's up":}
+      fail("The NeSI Puppet Puppet module does not support ${::osfamily} family of operating systems")
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class puppet::params{
   $minimum_basemodulepath = ['/opt/puppet/share/puppet/modules']
   $autosign_conf_path     = "${conf_dir}/autosign.conf"
 
-  if ($::facterversion > 3) {
+  if (versioncmp($::facterversion) > 3) {
     $family = $::os[family]
   } else {
     $family = $::osfamily

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,15 +27,7 @@ class puppet::params{
   $minimum_basemodulepath = ['/opt/puppet/share/puppet/modules']
   $autosign_conf_path     = "${conf_dir}/autosign.conf"
 
-  if (versioncmp($::facterversion, "3.0") > 0) {
-    $family = $::os[family]
-  } else {
-    $family = $::osfamily
-  }
-
-  notify{"This is my family: $family":}
-
-  case $family {
+  case $::osfamily {
     "Debian":{
       # Do nothing
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,13 +35,13 @@ class puppet::params{
 
   notify{"This is my family: $family":}
 
-  #case $family {
-  #  Debian:{
-  #    # Do nothing
-  #  }
-  #  default:{
-  #    fail("The NeSI Puppet Puppet module does not support ${::osfamily} family of operating systems")
-  #  }
-  #}
+  case $family {
+    Debian:{
+      # Do nothing
+    }
+    default:{
+      fail("The NeSI Puppet Puppet module does not support ${::osfamily} family of operating systems")
+    }
+  }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,8 +27,13 @@ class puppet::params{
   $minimum_basemodulepath = ['/opt/puppet/share/puppet/modules']
   $autosign_conf_path     = "${conf_dir}/autosign.conf"
 
+  if ($::facterversion > 3) {
+    $family = $::os[family]
+  } else {
+    $family = $::osfamily
+  }
 
-  case $::osfamily {
+  case $family {
     Debian:{
       # Do nothing
     }
@@ -36,4 +41,5 @@ class puppet::params{
       fail("The NeSI Puppet Puppet module does not support ${::osfamily} family of operating systems")
     }
   }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,6 +41,7 @@ class puppet::params{
     }
     default:{
       #fail("The NeSI Puppet Puppet module does not support ${::osfamily} family of operating systems")
+      notify{"What's up":}
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class puppet::params{
   $minimum_basemodulepath = ['/opt/puppet/share/puppet/modules']
   $autosign_conf_path     = "${conf_dir}/autosign.conf"
 
-  if (versioncmp($::facterversion) > 3) {
+  if (versioncmp($::facterversion, 3.0) > 0) {
     $family = $::os[family]
   } else {
     $family = $::osfamily

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,7 @@ class puppet::params{
   notify{"This is my family: $family":}
 
   case $family {
-    Debian:{
+    "Debian":{
       # Do nothing
     }
     default:{

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,8 @@ class puppet::params{
     $family = $::osfamily
   }
 
+  notify{"This is my family: $family":}
+
   case $family {
     Debian:{
       # Do nothing

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class puppet::params{
   $minimum_basemodulepath = ['/opt/puppet/share/puppet/modules']
   $autosign_conf_path     = "${conf_dir}/autosign.conf"
 
-  if (versioncmp($::facterversion, 3.0) > 0) {
+  if (versioncmp($::facterversion, "3.0") > 0) {
     $family = $::os[family]
   } else {
     $family = $::osfamily

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,13 +35,13 @@ class puppet::params{
 
   notify{"This is my family: $family":}
 
-  case $family {
-    Debian:{
-      # Do nothing
-    }
-    default:{
-      fail("The NeSI Puppet Puppet module does not support ${::osfamily} family of operating systems")
-    }
-  }
+  #case $family {
+  #  Debian:{
+  #    # Do nothing
+  #  }
+  #  default:{
+  #    fail("The NeSI Puppet Puppet module does not support ${::osfamily} family of operating systems")
+  #  }
+  #}
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,7 @@ class puppet::params{
       # Do nothing
     }
     default:{
-      fail("The NeSI Puppet Puppet module does not support ${::osfamily} family of operating systems")
+      #fail("The NeSI Puppet Puppet module does not support ${::osfamily} family of operating systems")
     }
   }
 


### PR DESCRIPTION
Added quotes for case values in params.pp. The current implementation does not support Puppet 4.2 and Facter 3.1. This change should not affect backward compatibility.